### PR TITLE
Feature/drag n drop#20

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ The app has some simple hotkeys:
 | <kbd>t</kbd>         | Toggle Transparency (returning to fully transparent is not supported) |
 | <kbd>r</kbd>         | Toggle Rotating shape                                                 |
 | <kbd>spacebar </kbd> | Takes a screenshot && versions the current `.wgsl`                    |
+| <kbd>0</kbd>         | Select the `texture` at index 0                                       |
+| <kbd>1</kbd>         | Select the `texture` at index 1 (assuming you drag-n-dropped a tex onto shadplay)|
+| <kbd>2</kbd>         | Select the `texture` at index 2                                       |
+| <kbd>3</kbd>         | Select the `texture` at index 3                                       |
+| <kbd>4</kbd>         | Select the `texture` at index 4                                       |
+| <kbd>5</kbd>         | Select the `texture` at index 5                                       |
+| <kbd>6</kbd>         | Select the `texture` at index 6                                       |
+| <kbd>7</kbd>         | Select the `texture` at index 7                                       |
+| <kbd>8</kbd>         | Select the `texture` at index 8                                       |
+| <kbd>9</kbd>         | Select the `texture` at index 9                                       |
 
 ______________________________________________________________________
 

--- a/assets/shaders/howto-texture.wgsl
+++ b/assets/shaders/howto-texture.wgsl
@@ -1,10 +1,9 @@
-
 //! Showing how to use a texture, drag-n-drop for you own texture will be supported soon.
 
 #import bevy_pbr::mesh_vertex_output      MeshVertexOutput
 
-@group(1) @binding(0) var texture: texture_2d<f32>;
-@group(1) @binding(1) var texture_sampler: sampler;
+@group(1) @binding(1) var texture: texture_2d<f32>;
+@group(1) @binding(2) var texture_sampler: sampler;
 
 @fragment
 fn fragment(in: MeshVertexOutput) -> @location(0) vec4<f32> {

--- a/assets/shaders/myshader_2d.wgsl
+++ b/assets/shaders/myshader_2d.wgsl
@@ -1,26 +1,17 @@
-/// ***************************** ///
-/// THIS IS THE DEFAULT 2D SHADER ///
-/// You can always get back to this with `python3 scripts/reset-2d.py` ///
-/// ***************************** ///
+//! Showing how to use a texture, drag-n-drop for you own texture will be supported soon.
 
-#import bevy_pbr::mesh_vertex_output MeshVertexOutput
-#import bevy_sprite::mesh2d_view_bindings globals 
-#import shadplay::shader_utils::common NEG_HALF_PI, shaderToyDefault, rotate2D
+#import bevy_pbr::mesh_vertex_output      MeshVertexOutput
 
-#import bevy_render::view  View
-@group(0) @binding(0) var<uniform> view: View;
-
-const SPEED:f32 = 1.0;
+@group(1) @binding(1) var texture: texture_2d<f32>;
+@group(1) @binding(2) var texture_sampler: sampler;
 
 @fragment
 fn fragment(in: MeshVertexOutput) -> @location(0) vec4<f32> {
     // ensure our uv coords match shadertoy/the-lil-book-of-shaders
-    var uv = (in.uv * 2.0) - 1.0;
-    let resolution = view.viewport.zw;
-    let t = globals.time * SPEED;
-    uv.x *= resolution.x / resolution.y;
-    uv *= rotate2D(NEG_HALF_PI);
+    let texture_uvs = in.uv;
 
-    return vec4f(shaderToyDefault(t, uv), 1.0);
+    let tex: vec4f = textureSample(texture, texture_sampler, texture_uvs); 
+
+    return tex;
 }    
     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,12 @@ pub mod drag_n_drop {
                             KeyCode::Key8 => set_current_tex(shad_mat, 8, &user_textures),
                             KeyCode::Key9 => set_current_tex(shad_mat, 9, &user_textures),
                             KeyCode::Key0 => set_current_tex(shad_mat, 0, &user_textures),
-                            _ => return,
+                            _ => (),
                         },
-                        _ => return,
-                    };
+                        _ => (),
+                    }
                 }
-                _ => return,
+                _ => (),
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,64 @@ pub mod screenshot;
 pub mod shader_utils;
 pub mod ui;
 pub mod utils;
+
+pub mod drag_n_drop {
+    use bevy::prelude::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// Resource: Representing the index (the default texture will be at 0), and a Texture handle that we can pass to a shader
+    #[derive(Default, Resource, Deref, DerefMut, Clone, Debug)]
+    pub struct TexHandleQueue(pub HashMap<usize, Handle<Image>>);
+
+    /// Event: used to store user defined textures that we allow them to drop onto the window.
+    /// TX:
+    /// RX:
+    #[derive(Event, Deref, DerefMut, Clone, Debug)]
+    pub struct UserAddedTexture(PathBuf);
+
+    /// Supported textures extensions
+    static AVAILABLE_TEX_FORMATS: [&str; 3] = ["png", "jpeg", "jpg"];
+
+    /// Listens for .png and .jpeg files dropped onto the window.
+    pub fn file_drag_and_drop_listener(
+        mut events: EventReader<FileDragAndDrop>,
+        mut texture_tx: EventWriter<UserAddedTexture>,
+    ) {
+        events.into_iter().for_each(|event| match event {
+            FileDragAndDrop::DroppedFile { path_buf, .. } => {
+                texture_tx.send(UserAddedTexture(path_buf.clone()));
+                debug!("TX: {:?}", event);
+            }
+            _ => {}
+        });
+    }
+
+    /// Add the user's dropped file to our available textures
+    pub fn add_dropped_file(
+        // mut commands: Commands,
+        asset_server: Res<AssetServer>,
+        mut user_textures: EventReader<UserAddedTexture>,
+        mut handle_queue: ResMut<TexHandleQueue>,
+    ) {
+        user_textures.into_iter().for_each(|tex_path| {
+            if AVAILABLE_TEX_FORMATS.iter().any(|fmt| {
+                tex_path
+                    .extension()
+                    .is_some_and(|x| x.to_string_lossy().contains(fmt))
+            }) {
+                debug!("RX: {:?}", tex_path.display());
+            } else {
+                debug!("ANY FAIL ON: {:?}", tex_path.display());
+            };
+            // Add texture to asset_server
+            let texture: Handle<Image> = asset_server.load(tex_path.as_path());
+
+            // get highest index
+            let new_idx = handle_queue.keys().count();
+
+            //TODO: log
+            handle_queue.insert(new_idx, texture);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ui;
 pub mod utils;
 
 pub mod drag_n_drop {
+    use crate::shader_utils::set_current_tex;
     #[allow(unused_imports)] //FIXME: after implementing texture on 3d...
     use crate::shader_utils::{YourShader, YourShader2D};
     use bevy::input::keyboard::KeyboardInput;
@@ -85,16 +86,16 @@ pub mod drag_n_drop {
                     ButtonState::Pressed => {
                         match ev.key_code {
                             Some(v) => match v {
-                                KeyCode::Key1 => shad_mat.set_current_tex(1),
-                                KeyCode::Key2 => shad_mat.set_current_tex(2),
-                                KeyCode::Key3 => shad_mat.set_current_tex(3),
-                                KeyCode::Key4 => shad_mat.set_current_tex(4),
-                                KeyCode::Key5 => shad_mat.set_current_tex(5),
-                                KeyCode::Key6 => shad_mat.set_current_tex(6),
-                                KeyCode::Key7 => shad_mat.set_current_tex(7),
-                                KeyCode::Key8 => shad_mat.set_current_tex(8),
-                                KeyCode::Key9 => shad_mat.set_current_tex(9),
-                                KeyCode::Key0 => shad_mat.set_current_tex(0),
+                                KeyCode::Key1 => set_current_tex(shad_mat, 1, &user_textures),
+                                KeyCode::Key2 => set_current_tex(shad_mat, 2, &user_textures),
+                                KeyCode::Key3 => set_current_tex(shad_mat, 3, &user_textures),
+                                KeyCode::Key4 => set_current_tex(shad_mat, 4, &user_textures),
+                                KeyCode::Key5 => set_current_tex(shad_mat, 5, &user_textures),
+                                KeyCode::Key6 => set_current_tex(shad_mat, 6, &user_textures),
+                                KeyCode::Key7 => set_current_tex(shad_mat, 7, &user_textures),
+                                KeyCode::Key8 => set_current_tex(shad_mat, 8, &user_textures),
+                                KeyCode::Key9 => set_current_tex(shad_mat, 9, &user_textures),
+                                KeyCode::Key0 => set_current_tex(shad_mat, 0, &user_textures),
                                 _ => return,
                             },
                             _ => return,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,7 @@ pub mod utils;
 
 pub mod drag_n_drop {
     use crate::shader_utils::set_current_tex;
-    #[allow(unused_imports)] //FIXME: after implementing texture on 3d...
-    use crate::shader_utils::{YourShader, YourShader2D};
+    use crate::shader_utils::YourShader2D;
     use bevy::input::keyboard::KeyboardInput;
     use bevy::input::ButtonState;
     use bevy::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,12 @@ pub mod ui;
 pub mod utils;
 
 pub mod drag_n_drop {
+    #[allow(unused_imports)] //FIXME: after implementing texture on 3d...
+    use crate::shader_utils::{YourShader, YourShader2D};
+    use bevy::input::keyboard::KeyboardInput;
+    use bevy::input::ButtonState;
     use bevy::prelude::*;
+
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -18,10 +23,11 @@ pub mod drag_n_drop {
     #[derive(Event, Deref, DerefMut, Clone, Debug)]
     pub struct UserAddedTexture(PathBuf);
 
-    /// Supported textures extensions
+    /// Supported textures extensions for the drag-n-drop your texture functionality
+    /// Update this in future if we're going to support more extensions.
     static AVAILABLE_TEX_FORMATS: [&str; 3] = ["png", "jpeg", "jpg"];
 
-    /// Listens for .png and .jpeg files dropped onto the window.
+    /// System: Listens for .png and .jpeg files dropped onto the window.
     pub fn file_drag_and_drop_listener(
         mut events: EventReader<FileDragAndDrop>,
         mut texture_tx: EventWriter<UserAddedTexture>,
@@ -35,9 +41,8 @@ pub mod drag_n_drop {
         });
     }
 
-    /// Add the user's dropped file to our available textures
+    /// System: Add the user's dropped file to our available textures
     pub fn add_dropped_file(
-        // mut commands: Commands,
         asset_server: Res<AssetServer>,
         mut user_textures: EventReader<UserAddedTexture>,
         mut handle_queue: ResMut<TexHandleQueue>,
@@ -50,16 +55,54 @@ pub mod drag_n_drop {
             }) {
                 debug!("RX: {:?}", tex_path.display());
             } else {
+                //FIXME: remove this branch entirely, we won't need it.
                 debug!("ANY FAIL ON: {:?}", tex_path.display());
             };
-            // Add texture to asset_server
             let texture: Handle<Image> = asset_server.load(tex_path.as_path());
 
-            // get highest index
             let new_idx = handle_queue.keys().count();
-
             //TODO: log
             handle_queue.insert(new_idx, texture);
+            debug!("New Tex @{}", new_idx);
         });
+    }
+
+    /// System: using the keys 0-9, swap the current texture to that idx.
+    pub fn swap_tex_to_idx_2d(
+        mut key_evr: EventReader<KeyboardInput>,
+        shader_hndl: Query<&Handle<YourShader2D>>,
+        mut shader_mat: ResMut<Assets<YourShader2D>>,
+        user_textures: Res<TexHandleQueue>,
+        // mut shader_mat_3d: ResMut<Assets<YourShader>>, // FIXME: Support this.
+    ) {
+        let Ok(handle) = shader_hndl.get_single() else {
+            return;
+        };
+        if let Some(shad_mat) = shader_mat.get_mut(handle) {
+            for ev in key_evr.iter() {
+                // debug!("{} pressed, moving to that Tex idx.", keynum);
+                match ev.state {
+                    ButtonState::Pressed => {
+                        match ev.key_code {
+                            Some(v) => match v {
+                                KeyCode::Key1 => shad_mat.set_current_tex(1),
+                                KeyCode::Key2 => shad_mat.set_current_tex(2),
+                                KeyCode::Key3 => shad_mat.set_current_tex(3),
+                                KeyCode::Key4 => shad_mat.set_current_tex(4),
+                                KeyCode::Key5 => shad_mat.set_current_tex(5),
+                                KeyCode::Key6 => shad_mat.set_current_tex(6),
+                                KeyCode::Key7 => shad_mat.set_current_tex(7),
+                                KeyCode::Key8 => shad_mat.set_current_tex(8),
+                                KeyCode::Key9 => shad_mat.set_current_tex(9),
+                                KeyCode::Key0 => shad_mat.set_current_tex(0),
+                                _ => return,
+                            },
+                            _ => return,
+                        };
+                    }
+                    _ => return,
+                }
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@ pub mod drag_n_drop {
             };
             let texture: Handle<Image> = asset_server.load(tex_path.as_path());
 
-            let new_idx = handle_queue.keys().count();
-            //TODO: log
+            let new_idx = handle_queue.keys().count(); // TODO: make the default texture at 0
             handle_queue.insert(new_idx, texture);
+
             debug!("New Tex @{}", new_idx);
         });
     }
@@ -81,9 +81,9 @@ pub mod drag_n_drop {
         };
         if let Some(shad_mat) = shader_mat.get_mut(handle) {
             for ev in key_evr.iter() {
-                // debug!("{} pressed, moving to that Tex idx.", keynum);
                 match ev.state {
                     ButtonState::Pressed => {
+                        debug!("{:?} pressed, moving to that Tex idx.", ev.key_code);
                         match ev.key_code {
                             Some(v) => match v {
                                 KeyCode::Key1 => set_current_tex(shad_mat, 1, &user_textures),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ use bevy_panorbit_camera::PanOrbitCameraPlugin;
 #[cfg(feature = "ui")]
 use shadplay::ui::HelpUIPlugin;
 use shadplay::{
+    drag_n_drop::{
+        add_dropped_file, file_drag_and_drop_listener, TexHandleQueue, UserAddedTexture,
+    },
     screenshot, shader_utils,
     utils::{self, AppState, MonitorsSpecs, Rotating, ShapeOptions, TransparencySet},
 };
@@ -45,11 +48,14 @@ fn main() {
         .add_plugins(Material2dPlugin::<shader_utils::YourShader2D>::default())
         // Resources
         .insert_resource(MonitorsSpecs::default())
+        .insert_resource(TexHandleQueue::default())
         .insert_resource(utils::ShadplayWindowDims::default())
         .insert_resource(ShapeOptions::default())
         .insert_resource(TransparencySet(true))
         .insert_resource(Rotating(false))
         .add_plugins(PanOrbitCameraPlugin)
+        //events:
+        .add_event::<UserAddedTexture>()
         // 3D
         .add_systems(OnEnter(AppState::ThreeD), utils::setup_3d)
         .add_systems(OnExit(AppState::ThreeD), utils::cleanup_3d)
@@ -73,6 +79,8 @@ fn main() {
         .add_systems(
             Update,
             (
+                file_drag_and_drop_listener,
+                add_dropped_file, //.run_if(on_event::<UserAddedTexture>()),
                 screenshot::screenshot_and_version_shader_on_spacebar,
                 utils::cam_switch_system,
                 utils::quit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,8 @@ use bevy_panorbit_camera::PanOrbitCameraPlugin;
 use shadplay::ui::HelpUIPlugin;
 use shadplay::{
     drag_n_drop::{
-        add_dropped_file, file_drag_and_drop_listener, TexHandleQueue, UserAddedTexture,
+        add_dropped_file, file_drag_and_drop_listener, swap_tex_to_idx_2d, TexHandleQueue,
+        UserAddedTexture,
     },
     screenshot, shader_utils,
     utils::{self, AppState, MonitorsSpecs, Rotating, ShapeOptions, TransparencySet},
@@ -80,7 +81,8 @@ fn main() {
             Update,
             (
                 file_drag_and_drop_listener,
-                add_dropped_file, //.run_if(on_event::<UserAddedTexture>()),
+                add_dropped_file.run_if(on_event::<UserAddedTexture>()),
+                swap_tex_to_idx_2d, //.run_if(resource_changed::<TexHandleQueue>()), //FIXME:
                 screenshot::screenshot_and_version_shader_on_spacebar,
                 utils::cam_switch_system,
                 utils::quit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use bevy_panorbit_camera::PanOrbitCameraPlugin;
 use shadplay::ui::HelpUIPlugin;
 use shadplay::{
     drag_n_drop::{
-        add_dropped_file, file_drag_and_drop_listener, swap_tex_to_idx_2d, TexHandleQueue,
+        add_dropped_file, file_drag_and_drop_listener, swap_tex_to_idx, TexHandleQueue,
         UserAddedTexture,
     },
     screenshot, shader_utils,
@@ -82,7 +82,7 @@ fn main() {
             (
                 file_drag_and_drop_listener,
                 add_dropped_file.run_if(on_event::<UserAddedTexture>()),
-                swap_tex_to_idx_2d, //.run_if(resource_changed::<TexHandleQueue>()), //FIXME:
+                swap_tex_to_idx, //.run_if(resource_changed::<TexHandleQueue>()), //FIXME:
                 screenshot::screenshot_and_version_shader_on_spacebar,
                 utils::cam_switch_system,
                 utils::quit,

--- a/src/shader_utils.rs
+++ b/src/shader_utils.rs
@@ -58,7 +58,7 @@ impl Material2d for YourShader2D {
 }
 
 /// Helper to set/override the current texture on the 2d Shader
-pub fn set_current_tex(
+pub(crate) fn set_current_tex(
     shader_mat: &mut YourShader2D,
     idx: usize,
     user_added_textures: &TexHandleQueue,

--- a/src/shader_utils.rs
+++ b/src/shader_utils.rs
@@ -9,7 +9,7 @@ use bevy::{
     // window::PrimaryWindow,
 };
 
-use crate::drag_n_drop::UserAddedTexture;
+use crate::drag_n_drop::TexHandleQueue;
 
 pub mod common;
 
@@ -34,13 +34,12 @@ impl Material for YourShader {
 //                2D                    //
 // ************************************ //
 /// The 2D shadertoy like shader
-#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Deref)]
+#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone)]
 #[uuid = "f528511f-dcf2-4b0b-9522-a9df3a1a795b"]
 pub struct YourShader2D {
-    /// Mouse X and Mouse Y
     #[uniform(0)]
     pub(crate) mouse_pos: MousePos,
-    // /// to replicate iChannel
+
     #[texture(1, dimension = "2d")]
     #[sampler(2)]
     pub img: Handle<Image>,
@@ -58,10 +57,17 @@ impl Material2d for YourShader2D {
     }
 }
 
-impl YourShader2D {
-    pub fn set_current_tex(&self, idx: usize, user_added_textures: &UserAddedTexture) {
-        todo!()
-    }
+/// Helper to set/override the current texture on the 2d Shader
+pub fn set_current_tex(
+    shader_mat: &mut YourShader2D,
+    idx: usize,
+    user_added_textures: &TexHandleQueue,
+) {
+    let Some(new_tex) = user_added_textures.0.get(&idx) else {
+        error!("Expected a texture at idx: {}, but none was found.", idx);
+        return;
+    };
+    shader_mat.img = new_tex.clone(); // Cloning handles is fine.
 }
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ----

--- a/src/shader_utils.rs
+++ b/src/shader_utils.rs
@@ -9,6 +9,8 @@ use bevy::{
     // window::PrimaryWindow,
 };
 
+use crate::drag_n_drop::UserAddedTexture;
+
 pub mod common;
 
 // ************************************ //
@@ -32,7 +34,7 @@ impl Material for YourShader {
 //                2D                    //
 // ************************************ //
 /// The 2D shadertoy like shader
-#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone)]
+#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Deref)]
 #[uuid = "f528511f-dcf2-4b0b-9522-a9df3a1a795b"]
 pub struct YourShader2D {
     /// Mouse X and Mouse Y
@@ -53,6 +55,12 @@ pub struct MousePos {
 impl Material2d for YourShader2D {
     fn fragment_shader() -> ShaderRef {
         "shaders/myshader_2d.wgsl".into()
+    }
+}
+
+impl YourShader2D {
+    pub fn set_current_tex(&self, idx: usize, user_added_textures: &UserAddedTexture) {
+        todo!()
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,9 +94,6 @@ impl ShadplayWindowDims {
 
     /// Normalise the width (0) and height (1) on Self, to -0.5, to 0.5
     pub(crate) fn to_uv(&self, xy: Vec2) -> Vec2 {
-        #[cfg(debug_assertions)] //FIXME:
-        bevy::log::debug!("pre norm: {:?}", self);
-
         Vec2 {
             x: xy.x / (self.x / 2.0) - 1.0,
             y: xy.y / (self.y / 2.0) - 1.0,
@@ -390,7 +387,7 @@ pub fn setup_2d(
             }),
 
             transform: Transform::from_translation(Vec3::new(0., 0., 0.)),
-            // .with_rotation(Quat::from_rotation_x(180.0)),
+            // .with_rotation(Quat::from_rotation_x(180.0)), //FIXME to avoid the rotate2D call in all shaders..
             ..default()
         },
         BillBoardQuad,
@@ -410,7 +407,6 @@ pub fn size_quad(
         .expect("Should be impossible to NOT get a window");
 
     let (width, height) = (win.width(), win.height());
-    // let (max_width, max_height) = possy.get_single()
 
     query.iter_mut().for_each(|mut transform| {
         *msd = ShadplayWindowDims(Vec2 {
@@ -418,7 +414,6 @@ pub fn size_quad(
             y: height,
         });
 
-        // transform.translation = Vec3::new(0.0, 0.0, 0.0);
         transform.scale = Vec3::new(width * 0.95, height * 0.95, 1.0);
         trace!("Window Resized, resizing quad");
     });
@@ -453,26 +448,13 @@ pub fn update_mouse_pos(
     };
     let Some(mouse_xy) = win.physical_cursor_position() else {
         return;
-        // full monitor width/height
-        // let mon_full_w = mon_spec.xy().x;
-        // let mon_full_h = mon_spec.xy().y;
     };
 
     // Is the mouse on our window?
     if shadplay_win_dims.hittest(mouse_xy) {
-        #[cfg(debug_assertions)] //FIXME:
-        bevy::log::debug!("hittest = true");
-
         if let Some(shad_mat) = shader_mat.get_mut(handle) {
-            // Shadplay window's size
-            #[cfg(debug_assertions)] //FIXME:
-            bevy::log::debug!("mouseIN : {:?}", mouse_xy);
-
             let sh_xy = shadplay_win_dims.to_uv(mouse_xy);
             shad_mat.mouse_pos = sh_xy.into();
-
-            #[cfg(debug_assertions)] //FIXME:
-            bevy::log::debug!("mouseOUT:{:?}", shad_mat.mouse_pos);
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,10 @@ use bevy::{
 };
 use bevy_panorbit_camera::PanOrbitCamera;
 
-use crate::shader_utils::{MousePos, YourShader, YourShader2D};
+use crate::{
+    drag_n_drop::TexHandleQueue,
+    shader_utils::{MousePos, YourShader, YourShader2D},
+};
 
 /// State: Used to transition between 2d and 3d mode.    
 /// Used by: cam_switch_system, screenshot
@@ -337,15 +340,20 @@ pub fn cam_switch_system(
 }
 
 /// System: initialises 2d Camera. Called on entry of [`AppState::TwoD`]
+/// NOTE: this also initialises the [`TexHandleQueue`], the default texture is bound to 0 by this system on startup.
 pub fn setup_2d(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut your_shader: ResMut<Assets<YourShader2D>>,
     mut msd: ResMut<ShadplayWindowDims>,
+    mut user_textures: ResMut<TexHandleQueue>,
     asset_server: Res<AssetServer>,
     windows: Query<&Window>,
 ) {
+    //FIXME:
+    // TODO: hoist this into its own startup initialiser.
     let texture: Handle<Image> = asset_server.load("textures/space.jpg");
+    user_textures.insert(0, texture.clone());
 
     // 2D camera
     commands.spawn((


### PR DESCRIPTION
- Adds drag-n-drop to add textures to the `AssetServer` so that you can use your own in your own shaders.
- Currently supported on 2d.
- keys 0 through 9 are the hotkeys to toggle between the textures you've added, as you add them the index increases.
- The 0th one is the default.