### PR TITLE
long-lived app config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ checksum = "a44e4e2784a81430199e4157e02903a987a32127c773985506f020e7d501b62e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -530,7 +530,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ checksum = "23ddc18d489b4e57832d4958cde7cd2f349f0ad91e5892ac9e2f2ee16546b981"
 dependencies = [
  "quote",
  "rustc-hash",
- "syn 2.0.25",
+ "syn 2.0.38",
  "toml_edit",
 ]
 
@@ -808,7 +808,7 @@ dependencies = [
  "bit-set",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
  "uuid",
 ]
 
@@ -871,7 +871,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1040,7 +1040,7 @@ checksum = "5391b242c36f556db01d5891444730c83aa9dd648b6a8fd2b755d22cb3bddb57"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1536,6 +1536,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1635,7 @@ checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1915,7 +1936,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2738,7 +2759,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2852,6 +2873,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -2994,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -3065,6 +3092,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -3203,22 +3241,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3241,7 +3279,9 @@ dependencies = [
  "bevy_panorbit_camera",
  "chrono",
  "copypasta",
+ "directories",
  "glob",
+ "serde",
 ]
 
 [[package]]
@@ -3378,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3459,7 +3499,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3535,7 +3575,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3719,7 +3759,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -3753,7 +3793,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,19 +1639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "epaint"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,12 +2069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "hexasphere"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,12 +2092,6 @@ checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -2239,17 +2214,6 @@ checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
 dependencies = [
  "core-foundation-sys 0.8.4",
  "mach2",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3046,16 +3010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,8 +3291,6 @@ dependencies = [
  "copypasta",
  "directories",
  "glob",
- "log",
- "pretty_env_logger",
  "serde",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "approx"
@@ -716,7 +716,7 @@ dependencies = [
  "quote",
  "rustc-hash",
  "syn 2.0.38",
- "toml_edit",
+ "toml_edit 0.19.13",
 ]
 
 [[package]]
@@ -1639,6 +1639,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "epaint"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hexasphere"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2111,12 @@ checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -2214,6 +2239,17 @@ checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
 dependencies = [
  "core-foundation-sys 0.8.4",
  "mach2",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2419,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "mach2"
@@ -3010,13 +3046,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.13",
 ]
 
 [[package]]
@@ -3271,9 +3317,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shadplay"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "bevy",
  "bevy_egui",
  "bevy_panorbit_camera",
@@ -3281,7 +3337,10 @@ dependencies = [
  "copypasta",
  "directories",
  "glob",
+ "log",
+ "pretty_env_logger",
  "serde",
+ "toml",
 ]
 
 [[package]]
@@ -3539,10 +3598,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
+name = "toml"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3551,6 +3625,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7"
 dependencies = [
  "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ copypasta = "0.10.0"
 directories = "5.0.1"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"
+log = "0.4.20"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"
-log = "0.4.20"
 anyhow = "1.0.75"
 
 [profile.dev] # A little bit of optimisation for dev builds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = ["ui"]
 ui = []
 
 [dependencies]
+anyhow = "1.0.75"
 bevy = { version = "0.11.3", features = [
   "filesystem_watcher",
   "dynamic_linking",
@@ -27,11 +28,8 @@ copypasta = "0.10.0"
 directories = "5.0.1"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"
-log = "0.4.20"
 
 [dev-dependencies]
-pretty_env_logger = "0.5.0"
-anyhow = "1.0.75"
 
 [profile.dev] # A little bit of optimisation for dev builds
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ chrono = "0.4.31"
 copypasta = "0.10.0"
 directories = "5.0.1"
 serde = { version = "1.0.190", features = ["derive"] }
+toml = "0.8.6"
+
+[dev-dependencies]
+pretty_env_logger = "0.5.0"
+log = "0.4.20"
+anyhow = "1.0.75"
 
 [profile.dev] # A little bit of optimisation for dev builds
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ bevy_egui = { version = "0.21.0" }
 bevy_panorbit_camera = "0.8.*"
 chrono = "0.4.31"
 copypasta = "0.10.0"
+directories = "5.0.1"
+serde = { version = "1.0.190", features = ["derive"] }
 
 [profile.dev] # A little bit of optimisation for dev builds
 opt-level = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@ pub mod system {
     #![allow(dead_code, unused_imports)]
     //! Logic and Helpers etc for dealing with the system Shadplay is running on, i.e
     //! the app's default config, long-lived settings and the clipboard interactions.
-    use bevy::{log, prelude::Resource, window::WindowLevel};
+    use bevy::{prelude::Resource, window::WindowLevel};
     use directories::ProjectDirs;
+    use log;
     use serde::{Deserialize, Serialize};
     use std::{
         fs,
@@ -32,18 +33,18 @@ pub mod system {
         fn get_config_path() -> PathBuf {
             match ProjectDirs::from("", "", "shadplay") {
                 Some(proj_dirs) => {
-                    let config_path = proj_dirs.config_dir().join("config.toml");
-                    log::info!("Config directory is: {}", config_path.display());
+                    let config_path_full = proj_dirs.config_dir().join("config.toml");
+                    log::info!("Config directory is: {}", config_path_full.display());
 
                     if !proj_dirs.config_dir().exists() {
-                        log::info!("config.toml doesn't exist, creating it...",);
-                        if let Err(e) = fs::create_dir_all(proj_dirs.config_dir()) {
+                        log::error!("config.toml doesn't exist, creating it...",);
+                        if let Err(e) = fs::create_dir_all(&config_path_full) {
                             log::error!("Failed to create directory: {:?}", e);
                         }
                         log::info!("config.toml created...",);
                     }
 
-                    config_path
+                    config_path_full
                 }
                 None => {
                     log::error!("Unable to find or create the config directory.");
@@ -96,13 +97,11 @@ pub mod system {
     #[cfg(test)]
     mod tests {
         use super::UserConfig;
-        use log;
         use pretty_env_logger;
         use std::fs;
 
         #[test]
         fn save_and_load_user_config() {
-            pretty_env_logger::init();
             // Setup: Create a sample UserConfig and save it to a temporary file
             let test_config = UserConfig {
                 window_dims: (1024.0, 768.0),
@@ -125,10 +124,8 @@ pub mod system {
 
         #[test]
         fn config_path_for_user_config() {
-            pretty_env_logger::init();
             let p = UserConfig::get_config_path();
             dbg!(&p);
-            assert!(p.exists());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod system {
         window_dims: (f32, f32),
         decorations: bool,
         always_on_top: bool,
-        last_updated: u64,
+        last_updated: u64, //Toml doesn't supprot u128
     }
 
     impl UserConfig {
@@ -102,6 +102,10 @@ pub mod system {
 
             let (width, height) = (win.width(), win.height());
             user_config.window_dims = (width, height);
+            user_config.last_updated = std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
 
             match user_config.save_to_toml(Self::get_config_path()) {
                 Ok(_) => log::info!("User's config.toml's screen dims were updated."),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,12 @@ pub mod system {
                 .expect("Should be impossible to NOT get a window");
 
             let (width, height) = (win.width(), win.height());
+
+            user_config.decorations = win.decorations;
+            user_config.always_on_top = match win.window_level {
+                WindowLevel::AlwaysOnTop => true,
+                _ => false,
+            };
             user_config.window_dims = (width, height);
             user_config.last_updated = std::time::SystemTime::now()
                 .duration_since(UNIX_EPOCH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,63 @@ pub mod system_clipboard;
 pub mod texture_tooling;
 pub mod ui;
 pub mod utils;
+
+pub mod system {
+    #![allow(dead_code, unused_imports)]
+    //! Logic and Helpers etc for dealing with the system Shadplay is running on, i.e
+    //! the app's default config, long-lived settings and the clipboard interactions.
+    use bevy::{prelude::Resource, window::WindowLevel};
+    use directories::ProjectDirs;
+    use serde::{Deserialize, Serialize};
+    use std::{path::PathBuf, time::UNIX_EPOCH};
+
+    #[derive(Resource, Debug, Serialize, Deserialize)]
+    struct UserConfig {
+        window_dims: (f32, f32),
+        decorations: bool,
+        always_on_top: bool,
+        last_updated: u64,
+    }
+
+    impl UserConfig {
+        fn get_config_path() -> PathBuf {
+            match ProjectDirs::from("", "shadplay", "settings.toml") {
+                Some(proj_dirs) => {
+                    println!("Config directory is: {:?}", proj_dirs.config_dir());
+                    return proj_dirs.config_dir().to_path_buf();
+                }
+                _ => Self::write_defaults()
+                    .expect("Unable to write default config to $PATH, this is an app error."), //FIXME:
+            }
+        }
+
+        fn from_file() -> Result<Self, std::io::Error> {
+            // Self { window_dims: , decorations: , always_on_top:  }
+            todo!()
+        }
+
+        fn write_defaults() -> Result<PathBuf, std::io::Error> {
+            // write the default to the location on disk,
+            // read that from_file, return it.
+            todo!()
+        }
+
+        fn write_to_disk(&self) -> Result<(), std::io::Error> {
+            todo!()
+        }
+    }
+
+    impl Default for UserConfig {
+        fn default() -> Self {
+            Self {
+                window_dims: (720.0, 480.0),
+                decorations: true,
+                always_on_top: true,
+                last_updated: std::time::SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod system {
     //! the app's default config, long-lived settings and the clipboard interactions.
     use bevy::{
         log,
-        prelude::Resource,
+        prelude::{Query, ResMut, Resource},
         window::{Window, WindowLevel},
     };
     use directories::ProjectDirs;
@@ -91,6 +91,21 @@ pub mod system {
             match self.always_on_top {
                 true => WindowLevel::AlwaysOnTop,
                 _ => WindowLevel::Normal,
+            }
+        }
+
+        /// System: When the screen dims change, we update the Self we have in the bevy [`Resource`]s.
+        pub fn runtime_updater(mut user_config: ResMut<UserConfig>, windows: Query<&Window>) {
+            let win = windows
+                .get_single()
+                .expect("Should be impossible to NOT get a window");
+
+            let (width, height) = (win.width(), win.height());
+            user_config.window_dims = (width, height);
+
+            match user_config.save_to_toml(Self::get_config_path()) {
+                Ok(_) => log::info!("User's config.toml's screen dims were updated."),
+                Err(e) => log::error!("Failed to update user's config {}", e),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,18 @@ pub mod system {
     #![allow(dead_code, unused_imports)]
     //! Logic and Helpers etc for dealing with the system Shadplay is running on, i.e
     //! the app's default config, long-lived settings and the clipboard interactions.
-    use bevy::{prelude::Resource, window::WindowLevel};
+    use bevy::{log, prelude::Resource, window::WindowLevel};
     use directories::ProjectDirs;
     use serde::{Deserialize, Serialize};
-    use std::{path::PathBuf, time::UNIX_EPOCH};
+    use std::{
+        fs,
+        io::{self, Read},
+        path::{Path, PathBuf},
+        time::UNIX_EPOCH,
+    };
 
-    #[derive(Resource, Debug, Serialize, Deserialize)]
-    struct UserConfig {
+    #[derive(Resource, Debug, Serialize, PartialEq, PartialOrd, Deserialize)]
+    pub struct UserConfig {
         window_dims: (f32, f32),
         decorations: bool,
         always_on_top: bool,
@@ -25,29 +30,52 @@ pub mod system {
 
     impl UserConfig {
         fn get_config_path() -> PathBuf {
-            match ProjectDirs::from("", "shadplay", "settings.toml") {
+            match ProjectDirs::from("", "", "shadplay") {
                 Some(proj_dirs) => {
-                    println!("Config directory is: {:?}", proj_dirs.config_dir());
-                    return proj_dirs.config_dir().to_path_buf();
+                    let config_path = proj_dirs.config_dir().join("config.toml");
+                    log::info!("Config directory is: {}", config_path.display());
+
+                    if !proj_dirs.config_dir().exists() {
+                        log::info!("config.toml doesn't exist, creating it...",);
+                        if let Err(e) = fs::create_dir_all(proj_dirs.config_dir()) {
+                            log::error!("Failed to create directory: {:?}", e);
+                        }
+                        log::info!("config.toml created...",);
+                    }
+
+                    config_path
                 }
-                _ => Self::write_defaults()
-                    .expect("Unable to write default config to $PATH, this is an app error."), //FIXME:
+                None => {
+                    log::error!("Unable to find or create the config directory.");
+                    Self::write_defaults()
+                        .expect("Unable to write default config to $PATH, this is an app error.\n Please open an Issue: https://github.com/alphastrata/shadplay/issues")
+                }
             }
         }
 
-        fn from_file() -> Result<Self, std::io::Error> {
-            // Self { window_dims: , decorations: , always_on_top:  }
-            todo!()
-        }
-
         fn write_defaults() -> Result<PathBuf, std::io::Error> {
-            // write the default to the location on disk,
-            // read that from_file, return it.
-            todo!()
+            let default_path = Self::get_config_path();
+            Self::default().save_to_toml(&default_path)?;
+
+            Ok(default_path)
         }
 
-        fn write_to_disk(&self) -> Result<(), std::io::Error> {
-            todo!()
+        fn save_to_toml<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+            fs::write(
+                path,
+                toml::to_string(self).expect("Failed to serialize UserConfig to TOML"),
+            )?;
+
+            Ok(())
+        }
+
+        fn load_from_toml<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+            let mut file_contents = String::new();
+            fs::File::open(path)?.read_to_string(&mut file_contents)?;
+            let config: UserConfig =
+                toml::from_str(&file_contents).expect("Failed to deserialize TOML into UserConfig");
+
+            Ok(config)
         }
     }
 
@@ -62,6 +90,45 @@ pub mod system {
                     .unwrap_or_default()
                     .as_secs(),
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::UserConfig;
+        use log;
+        use pretty_env_logger;
+        use std::fs;
+
+        #[test]
+        fn save_and_load_user_config() {
+            pretty_env_logger::init();
+            // Setup: Create a sample UserConfig and save it to a temporary file
+            let test_config = UserConfig {
+                window_dims: (1024.0, 768.0),
+                decorations: false,
+                always_on_top: false,
+                last_updated: 1635900000,
+            };
+
+            let temp_path = "./temp_config.toml";
+            test_config
+                .save_to_toml(temp_path)
+                .expect("Failed to save test config to TOML");
+
+            let loaded_config = UserConfig::load_from_toml(temp_path)
+                .expect("Failed to load test config from TOML");
+            assert_eq!(test_config, loaded_config);
+
+            fs::remove_file(temp_path).expect("Failed to remove temporary test config file");
+        }
+
+        #[test]
+        fn config_path_for_user_config() {
+            pretty_env_logger::init();
+            let p = UserConfig::get_config_path();
+            dbg!(&p);
+            assert!(p.exists());
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,11 @@ use bevy::window::CompositeAlphaMode;
 
 use bevy::{
     asset::ChangeWatcher,
+    input::keyboard::KeyboardInput,
     prelude::*,
     sprite::Material2dPlugin,
     utils::Duration,
-    window::{WindowPlugin, WindowResized},
+    window::{WindowLevel, WindowPlugin, WindowResized},
 };
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
 
@@ -97,6 +98,7 @@ fn main() -> anyhow::Result<()> {
                 utils::switch_level,
                 utils::toggle_transparency,
                 utils::toggle_window_passthrough,
+                UserConfig::runtime_updater.run_if(on_event::<KeyboardInput>()),
                 UserConfig::runtime_updater.run_if(on_event::<WindowResized>()),
             ),
         )

--- a/src/ui/help_ui.rs
+++ b/src/ui/help_ui.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_egui::egui::epaint::Shadow;
 use bevy_egui::egui::{Align2, Color32, RichText, Rounding, Vec2};
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::{egui, EguiContexts};
 
 /// Plugin:
 /// Systems/Resources etc to facilitate the help UI which will show the hotkey bindings.
@@ -17,8 +17,6 @@ pub struct HelpUIToggle {
 
 impl Plugin for HelpUIPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(EguiPlugin);
-
         app.insert_resource(HelpUIToggle { open: false });
 
         app.add_systems(


### PR DESCRIPTION
adds a config.toml on default system config paths (using the directories crate) so preserve the window settings a user provides at runtime, or reads them from disk, should they want to tweak them when Shadplay is not running