### PR TITLE
fix: update some cheat-sheet links

### DIFF
--- a/bevy-shaders-cheatsheet.md
+++ b/bevy-shaders-cheatsheet.md
@@ -201,8 +201,8 @@ ______________________________________________________________________
 # get-data-into-your-shader
 
 If none of that makes sense: I wrote a [blog-post](https://jeremyfwebb.ninja/src/blog_posts/wgsl_basics), on this.
-Take this shader code [dotted-line-shader](https://github.com/alphastrata/shadplay/blob/develop/assets/shaders/dotted_line.wgsl)
-Then use this [rust-binding-code](https://github.com/alphastrata/shadplay/blob/develop/src/shader_utils.rs). (copied below for the lazy)
+Take this shader code [dotted-line-shader](https://github.com/alphastrata/shadplay/blob/main/assets/Gallery/lines/dotted_line.wgsl)
+Then use this [rust-binding-code](https://github.com/alphastrata/shadplay/blob/main/src/shader_utils/mod.rs#L70). (copied below for the lazy)
 
 ```rust
 // in src/YOURMODULE.rs


### PR DESCRIPTION
While reading the cheat-sheet, I noticed that 2 of the links were broken or outdated. I've updated them to point to what I believe were the intended pages.

Thank you for providing this fantastic resource!