### PR TITLE
Fix Windows Compile Errors

### DIFF
--- a/src/shader_utils/common.rs
+++ b/src/shader_utils/common.rs
@@ -1,13 +1,13 @@
 //! Bundles in our shader functions/consts etc declared in `shader_utils/common.wgsl` to make them importable.
 use bevy::{
-    asset::load_internal_asset,
+    asset::{load_internal_asset, weak_handle},
     prelude::{App, Handle, Plugin, Shader},
 };
 
 pub struct ShadplayShaderLibrary;
 
 pub const SHADPLAY_SHADER_LIBRARY_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(16813517719070609599);
+    weak_handle!("1d4373c8-5cfe-4779-9e71-f268b2e43fa9");
 
 impl Plugin for ShadplayShaderLibrary {
     fn build(&self, app: &mut App) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,7 +242,7 @@ pub fn toggle_window_passthrough(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut windows: Query<&mut Window>,
 ) {
-    if input.just_pressed(KeyCode::KeyX) {
+    if keyboard_input.just_pressed(KeyCode::KeyX) {
         let mut window = match windows.single_mut() {
             Ok(w) => w,
             Err(e) => {


### PR DESCRIPTION
# Notes
About `weak_handle!("1d4373c8-5cfe-4779-9e71-f268b2e43fa9");` in `src/shader_utils/common.rs`: I've generated the UUID using [this website](https://www.uuidgenerator.net/version4), feel free to generate others

# Result
Shadplay works on Windows!